### PR TITLE
Signal handling that does not segfault

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ build/
 *.o
 .lock-wscript
 tags
+.*.swp

--- a/src/ngtk_button.cc
+++ b/src/ngtk_button.cc
@@ -94,6 +94,11 @@ void Button::SetPrototypeMethods (Handle<FunctionTemplate> constructor_template)
   NGTK_SET_PROTOTYPE_METHOD(constructor_template, "setImage", Button::SetImage);
 }
 
+void Button::RegisterCallbacks (std::vector<SignalCallback> *callbacks) {
+  Widget::RegisterCallbacks(callbacks);
+  (*callbacks).push_back(SignalCallback("clicked", G_CALLBACK(Widget::SignalBare)));
+}
+
 void Button::Initialize (Handle<Object> target) {
   HandleScope scope;
 
@@ -103,6 +108,9 @@ void Button::Initialize (Handle<Object> target) {
   constructor_template->SetClassName(String::NewSymbol("Button"));
 
   Button::SetPrototypeMethods(constructor_template);
+
+  //Button::callbacks = new std::vector<SignalCallback>;
+  Button::RegisterCallbacks(Button::callbacks);
 
   target->Set(String::NewSymbol("Button"), constructor_template->GetFunction());
 }

--- a/src/ngtk_button.h
+++ b/src/ngtk_button.h
@@ -8,6 +8,7 @@ namespace ngtk {
 class Button : public Widget {
 public:
   static void       SetPrototypeMethods (v8::Handle<v8::FunctionTemplate> constructor_template);
+  static void       RegisterCallbacks   (std::vector<SignalCallback> *callbacks);
   static void       Initialize          (v8::Handle<v8::Object> target);
   static Button*    New                 (void); // public constructor
   static bool       HasInstance         (v8::Handle<v8::Value> val);
@@ -16,9 +17,10 @@ private:
   static v8::Persistent<v8::FunctionTemplate> constructor_template;
 
   static v8::Handle<v8::Value> New      (const v8::Arguments &args);
-  // gtk_button_*_label()
+
   static v8::Handle<v8::Value> SetLabel (const v8::Arguments &args);
   static v8::Handle<v8::Value> GetLabel (const v8::Arguments &args);
+
   static v8::Handle<v8::Value> SetImage (const v8::Arguments &args);
   static v8::Handle<v8::Value> SetImagePosition (const v8::Arguments &args);
 

--- a/src/ngtk_widget.cc
+++ b/src/ngtk_widget.cc
@@ -1,5 +1,6 @@
 #include "ngtk_widget.h"
 #include <node.h>
+#include <string.h>
 
 namespace ngtk {
 
@@ -9,19 +10,43 @@ using namespace node;
 // Add signal handler.
 Handle<Value> Widget::On (const Arguments &args) {
   HandleScope scope;
+  guint id = 0;
 
   if (args[0]->IsString() && args[1]->IsFunction()) {
     GtkWidget *widget = ObjectWrap::Unwrap<Widget>(args.This())->widget_;
+    GObject *object = G_OBJECT(widget);
 
     Persistent<Function> *callback = new Persistent<Function>();
     *callback = Persistent<Function>::New(Handle<Function>::Cast(args[1]));
+    gpointer callback_ptr = (gpointer) callback;
 
-    g_signal_connect(G_OBJECT(widget), *String::Utf8Value(args[0]->ToString()),
-        G_CALLBACK(Widget::onSignal), (gpointer) callback);
+    for (std::vector<SignalCallback>::iterator it = Widget::callbacks->begin(); it != Widget::callbacks->end(); ++it) {
+      if (strcmp(it->name, *String::AsciiValue(args[0]->ToString())) == 0) {
+        id = g_signal_connect(object, it->name, it->callback, callback_ptr);
+        break;
+      }
+    }
+
+    return scope.Close(v8::Number::New(id));
+  }
+
+  return scope.Close(v8::Boolean::New(false));
+}
+
+Handle<Value> Widget::Disconnect (const Arguments &args) {
+  if (args[0]->IsNumber()) {
+
+    GtkWidget *instance = Widget::Data(args.This());
+    int id = (int)(args[0]->NumberValue());
+
+    if (g_signal_handler_is_connected (instance, id)) {
+      g_signal_handler_disconnect (instance, id);
+    }
   }
 
   return args.This();
 }
+
 
 // Show()
 // For showing the widget.
@@ -38,20 +63,38 @@ Handle<Value> Widget::Show (const Arguments &args) {
 // For destroying widgets
 Handle<Value> Widget::Destroy (const Arguments &args) {
   HandleScope scope;
-
-  GtkWidget *widget = ObjectWrap::Unwrap<Widget>(args.This())->widget_;
-
+  GtkWidget *widget = Widget::Data(args.This());
   gtk_widget_destroy(widget);
-
   return args.This();
 }
 
-// Event handler.
-void Widget::onSignal (GtkWidget *widget, gpointer callback_ptr) {
+// For checking focus
+Handle<Value> Widget::IsFocus    (const v8::Arguments &args) {
   HandleScope scope;
+  GtkWidget *widget = Widget::Data(args.This());
+  return scope.Close(v8::Boolean::New(gtk_widget_is_focus(widget)));
+}
 
+// For grabbing focus
+Handle<Value> Widget::GrabFocus  (const v8::Arguments &args) {
+  HandleScope scope;
+  GtkWidget *widget = ObjectWrap::Unwrap<Widget>(args.This())->widget_;
+  gtk_widget_grab_focus(widget);
+  return args.This();
+}
+
+
+/**
+ * Bare signal. Used as the intermediate callback for various signals.
+ * Register a focus listener using @widget.on(signal, callback);@. Many signals
+ * are bare, this function handles all of them.
+ *
+ * Parameter:
+ *   widget - The widget that triggered the signal
+ *   callback_ptr - The user data, which is the JavaScript function to call
+ */
+void Widget::SignalBare(GtkWidget *widget, gpointer callback_ptr) {
   Persistent<Function> *callback = reinterpret_cast<Persistent<Function>*>(callback_ptr);
-
   TryCatch try_catch;
 
   (*callback)->Call(Context::GetCurrent()->Global(), 0, NULL);
@@ -61,14 +104,158 @@ void Widget::onSignal (GtkWidget *widget, gpointer callback_ptr) {
   }
 }
 
+
+/**
+ * Boolean signal. Used as the intermediate callback for various signals.
+ * Register a focus listener using @widget.on(signal, callback);@. Many signals
+ * are bare, but return a gboolean to indicate success/failure, or if the event
+ * should propagate. This function handles all of them.
+ *
+ * Parameter:
+ *   widget - The widget that triggered the signal
+ *   callback_ptr - The user data, which is the JavaScript function to call
+ *
+ * Returns:
+ * True or false, what ever the callback returns
+ */
+gboolean Widget::SignalBoolean(GtkWidget *widget, gpointer callback_ptr) {
+  Persistent<Function> *callback = reinterpret_cast<Persistent<Function>*>(callback_ptr);
+  TryCatch try_catch;
+
+  Local<Value> ret = (*callback)->Call(Context::GetCurrent()->Global(), 0, NULL);
+
+  if (try_catch.HasCaught()) {
+    FatalException(try_catch);
+  }
+
+  if (ret.IsEmpty()) {
+    printf("Bad return");
+  }
+
+  return (*ret)->IsTrue();
+}
+
+/**
+ * Focus signal. Used as the intermediate callback for focus signals.
+ * Register a focus listener using @widget.on('focus', callback);@
+ *
+ * Parameter:
+ *   widget - The widget that triggered the signal
+ *   dir - Tab forward, tab backwards, etc. See <GtkDirectionType> enum
+ *   callback_ptr - The user data, which is the JavaScript function to call
+ */
+gboolean Widget::SignalFocus(GtkWidget *widget, GtkDirectionType dir, gpointer callback_ptr) {
+  Persistent<Function> *callback = reinterpret_cast<Persistent<Function>*>(callback_ptr);
+  TryCatch try_catch;
+
+  Local<Value> argv[1] = { v8::Number::New(dir) };
+
+  Local<Value> ret = (*callback)->Call(Context::GetCurrent()->Global(), 1, argv);
+
+  if (try_catch.HasCaught()) {
+    FatalException(try_catch);
+  }
+
+  if (ret.IsEmpty()) {
+    printf("Bad return");
+  }
+
+  return (*ret)->IsTrue();
+}
+
+
+/**
+ * Bind methods on the JavaScript object to functions on the Widget class
+ */
 void Widget::SetPrototypeMethods (Handle<FunctionTemplate> constructor_template) {
   HandleScope scope;
 
-  NGTK_SET_PROTOTYPE_METHOD(constructor_template, "on",      Widget::On);
+  NGTK_SET_PROTOTYPE_METHOD(constructor_template, "on",         Widget::On);
+  NGTK_SET_PROTOTYPE_METHOD(constructor_template, "disconnect", Widget::Disconnect);
+
   // Maybe over-riden by Window for ev_ref etc.
-  NGTK_SET_PROTOTYPE_METHOD(constructor_template, "show",    Widget::Show);
-  NGTK_SET_PROTOTYPE_METHOD(constructor_template, "destroy", Widget::Destroy);
+  NGTK_SET_PROTOTYPE_METHOD(constructor_template, "show",       Widget::Show);
+  NGTK_SET_PROTOTYPE_METHOD(constructor_template, "destroy",    Widget::Destroy);
+
+  NGTK_SET_PROTOTYPE_METHOD(constructor_template, "isFocus",    Widget::IsFocus);
+  NGTK_SET_PROTOTYPE_METHOD(constructor_template, "grabFocus",  Widget::GrabFocus);
 }
+
+void Widget::RegisterCallbacks (std::vector<SignalCallback> *callbacks) {
+  (*callbacks).push_back(SignalCallback("focus", G_CALLBACK(Widget::SignalFocus)));
+
+  (*callbacks).push_back(SignalCallback("grab-focus", G_CALLBACK(Widget::SignalBare)));
+  (*callbacks).push_back(SignalCallback("hide", G_CALLBACK(Widget::SignalBare)));
+  (*callbacks).push_back(SignalCallback("map", G_CALLBACK(Widget::SignalBare)));
+  (*callbacks).push_back(SignalCallback("show", G_CALLBACK(Widget::SignalBare)));
+  (*callbacks).push_back(SignalCallback("realize", G_CALLBACK(Widget::SignalBare)));
+  (*callbacks).push_back(SignalCallback("unmap", G_CALLBACK(Widget::SignalBare)));
+  (*callbacks).push_back(SignalCallback("unrealize", G_CALLBACK(Widget::SignalBare)));
+
+  (*callbacks).push_back(SignalCallback("popup-menu", G_CALLBACK(Widget::SignalBoolean)));
+  (*callbacks).push_back(SignalCallback("destroy", G_CALLBACK(Widget::SignalBoolean)));
+}
+
+std::vector<SignalCallback> *Widget::callbacks = new std::vector<SignalCallback>;
+
+/*
+void Widget::SignalAccelClosuresChanged(GtkWidget *widget, gpointer callback_ptr) {
+  Persistent<Function> *callback = reinterpret_cast<Persistent<Function>*>(callback_ptr);
+}
+
+
+gboolean Widget::SignalButtonPressEvent(GtkWidget *widget, GdkEventButton *event, gpointer callback_ptr);
+gboolean Widget::SignalButtonReleaseEvent(GtkWidget *widget, GdkEventButton *event, gpointer callback_ptr);
+gboolean Widget::SignalCanActivateAccel(GtkWidget *widget, guint signal_id, gpointer callback_ptr);
+void Widget::SignalChildNotify(GtkWidget *widget, GParamSpec *pspec, gpointer callback_ptr);
+gboolean Widget::SignalClientEvent(GtkWidget *widget, GdkEventClient *event, gpointer callback_ptr);
+gboolean Widget::SignalConfigureEvent(GtkWidget *widget, GdkEventConfigure *event, gpointer callback_ptr);
+gboolean Widget::SignalDeleteEvent(GtkWidget *widget, GdkEvent *event, gpointer callback_ptr);
+gboolean Widget::SignalDestroyEvent(GtkWidget *widget, GdkEvent *event, gpointer callback_ptr);
+void Widget::SignalDirectionChanged(GtkWidget *widget, GtkTextDirection arg1, gpointer callback_ptr);
+void Widget::SignalDragBegin(GtkWidget *widget, GdkDragContext *drag_context, gpointer callback_ptr);
+void Widget::SignalDragDataDelete(GtkWidget *widget, GdkDragContext *drag_context, gpointer callback_ptr);
+void Widget::SignalDragDataGet(GtkWidget *widget, GdkDragContext *drag_context, GtkSelectionData *data, guint info, guint time, gpointer callback_ptr);
+void Widget::SignalDragDataReceived(GtkWidget *widget, GdkDragContext *drag_context, gint x, gint y, GtkSelectionData *data, guint info, guint time, gpointer callback_ptr);
+gboolean Widget::SignalDragDrop(GtkWidget *widget, GdkDragContext *drag_context, gint x, gint y, guint time, gpointer callback_ptr);
+void Widget::SignalDragEnd(GtkWidget *widget, GdkDragContext *drag_context, gpointer callback_ptr);
+void Widget::SignalDragLeave(GtkWidget *widget, GdkDragContext *drag_context, guint time, gpointer callback_ptr);
+gboolean Widget::SignalDragMotion(GtkWidget *widget, GdkDragContext *drag_context, gint x, gint y, guint time, gpointer callback_ptr);
+gboolean Widget::SignalEnterNotifyEvent(GtkWidget *widget, GdkEventCrossing *event, gpointer callback_ptr);
+gboolean Widget::SignalEvent(GtkWidget *widget, GdkEvent *event, gpointer callback_ptr);
+void Widget::SignalEventAfter(GtkWidget *widget, GdkEvent *event, gpointer callback_ptr);
+gboolean Widget::SignalExposeEvent(GtkWidget *widget, GdkEventExpose *event, gpointer callback_ptr);
+gboolean Widget::SignalFocusInEvent(GtkWidget *widget, GdkEventFocus *event, gpointer callback_ptr);
+gboolean Widget::SignalFocusOutEvent(GtkWidget *widget, GdkEventFocus *event, gpointer callback_ptr);
+void Widget::SignalGrabNotify(GtkWidget *widget, gboolean arg1, gpointer callback_ptr);
+void Widget::SignalHierarchyChanged(GtkWidget *widget, GtkWidget *widget2, gpointer callback_ptr);
+gboolean Widget::SignalKeyPressEvent(GtkWidget *widget, GdkEventKey *event, gpointer callback_ptr);
+gboolean Widget::SignalKeyReleaseEvent(GtkWidget *widget, GdkEventKey *event, gpointer callback_ptr);
+gboolean Widget::SignalLeaveNotifyEvent(GtkWidget *widget, GdkEventCrossing *event, gpointer callback_ptr);
+gboolean Widget::SignalMapEvent(GtkWidget *widget, GdkEvent *event, gpointer callback_ptr);
+gboolean Widget::SignalMnemonicActivate(GtkWidget *widget, gboolean arg1, gpointer callback_ptr);
+gboolean Widget::SignalMotionNotifyEvent(GtkWidget *widget, GdkEventMotion *event, gpointer callback_ptr);
+gboolean Widget::SignalNoExposeEvent(GtkWidget *widget, GdkEventNoExpose *event, gpointer callback_ptr);
+void Widget::SignalParentSet(GtkWidget *widget, GtkObject *old_parent, gpointer callback_ptr);
+gboolean Widget::SignalPropertyNotifyEvent(GtkWidget *widget, GdkEventProperty *event, gpointer callback_ptr);
+gboolean Widget::SignalProximityInEvent(GtkWidget *widget, GdkEventProximity *event, gpointer callback_ptr);
+gboolean Widget::SignalProximityOutEvent(GtkWidget *widget, GdkEventProximity *event, gpointer callback_ptr);
+void Widget::SignalScreenChanged(GtkWidget *widget, GdkScreen *arg1, gpointer callback_ptr);
+gboolean Widget::SignalScrollEvent(GtkWidget *widget, GdkEventScroll *event, gpointer callback_ptr);
+gboolean Widget::SignalSelectionClearEvent(GtkWidget *widget, GdkEventSelection *event, gpointer callback_ptr);
+void Widget::SignalSelectionGet(GtkWidget *widget, GtkSelectionData *data, guint info, guint time, gpointer callback_ptr);
+gboolean Widget::SignalSelectionNotifyEvent(GtkWidget *widget, GdkEventSelection *event, gpointer callback_ptr);
+void Widget::SignalSelectionReceived(GtkWidget *widget, GtkSelectionData *data, guint time, gpointer callback_ptr);
+gboolean Widget::SignalSelectionRequestEvent(GtkWidget *widget, GdkEventSelection *event, gpointer callback_ptr);
+gboolean Widget::SignalShowHelp(GtkWidget *widget, GtkWidgetHelpType arg1, gpointer callback_ptr);
+void Widget::SignalSizeAllocate(GtkWidget *widget, GtkAllocation *allocation, gpointer callback_ptr);
+void Widget::SignalSizeRequest(GtkWidget *widget, GtkRequisition *requisition, gpointer callback_ptr);
+void Widget::SignalStateChanged(GtkWidget *widget, GtkStateType state, gpointer callback_ptr);
+void Widget::SignalStyleSet(GtkWidget *widget, GtkStyle *previous_style, gpointer callback_ptr);
+gboolean Widget::SignalUnmapEvent(GtkWidget *widget, GdkEvent *event, gpointer callback_ptr);
+gboolean Widget::SignalVisibilityNotifyEvent(GtkWidget *widget, GdkEventVisibility *event, gpointer callback_ptr);
+gboolean Widget::SignalWindowStateEvent(GtkWidget *widget, GdkEventWindowState *event, gpointer user_data);
+*/
 
 
 } // namespace ngtk

--- a/src/ngtk_widget.h
+++ b/src/ngtk_widget.h
@@ -2,13 +2,26 @@
 #define NGTK_WIDGET_H_
 
 #include <node_object_wrap.h> // node::ObjectWrap
+#include "v8.h"
 #include "ngtk.h"
+#include <vector>
 
 namespace ngtk {
+
+struct SignalCallback {
+  const char *name;
+  GCallback callback;
+  
+  SignalCallback (const char *name, GCallback callback) {
+    this->name = name;
+    this->callback = callback;
+  }
+};
 
 class Widget : public node::ObjectWrap {
 public:
   static void SetPrototypeMethods (v8::Handle<v8::FunctionTemplate> constructor_template);
+  static void RegisterCallbacks   (std::vector<SignalCallback> *callbacks);
 
   // For getting the underlying GtkWidget
   static inline GtkWidget* Data (v8::Handle<v8::Object> obj) {
@@ -18,17 +31,30 @@ public:
 
   GtkWidget *widget_;
 
+  static std::vector<SignalCallback> *callbacks;
+
+  // Event handlers.
+  static void     SignalBare   (GtkWidget *widget, gpointer callback_ptr);
+  static gboolean SignalBoolean(GtkWidget *widget, gpointer callback_ptr);
+  static gboolean SignalFocus  (GtkWidget *widget, GtkDirectionType direction, gpointer callback_ptr);
+
 private:
   // Add signal handler.
-  static v8::Handle<v8::Value> On      (const v8::Arguments &args);
+  static v8::Handle<v8::Value> On         (const v8::Arguments &args);
+  // remove signal handler.
+  static v8::Handle<v8::Value> Disconnect (const v8::Arguments &args);
+
   // For showing the widget.
-  static v8::Handle<v8::Value> Show    (const v8::Arguments &args);
+  static v8::Handle<v8::Value> Show       (const v8::Arguments &args);
   // For destroying widgets
-  static v8::Handle<v8::Value> Destroy (const v8::Arguments &args);
-  // Event handler.
-  // TODO: Improve how we handle signals. Signals have variable arguments...
-  static void onSignal (GtkWidget *widget, gpointer callback_ptr);
+  static v8::Handle<v8::Value> Destroy    (const v8::Arguments &args);
+
+  // For checking focus
+  static v8::Handle<v8::Value> IsFocus    (const v8::Arguments &args);
+  // For grabbing focus
+  static v8::Handle<v8::Value> GrabFocus  (const v8::Arguments &args);
 };
+
 
 } // namespace ngtk
 

--- a/test.coffee
+++ b/test.coffee
@@ -1,18 +1,56 @@
+console.log 'test.js'
 gtk = require './build/default/gtk'
 
 process.nextTick ->
   gtk.init()
-  window = new gtk.Window
-  button = new gtk.Button
-  dialog = new gtk.MessageDialog(
-    window
-    gtk.DIALOG_DESTROY_WITH_PARENT
-    gtk.MESSAGE_INFO
-    gtk.BUTTONS_YES_NO
-    'This is an alert!'
-  )
-  window.container = new gtk.Vbox()
-  window.add(window.container)
 
+  window = new gtk.Window
+  hbox   = new gtk.Hbox
+  progress_hbox = new gtk.Hbox
+  window.add hbox
+
+  hbox2 = new gtk.Hbox
+  hbox3 = new gtk.Hbox
+  entry = new gtk.Entry
+  progressbar = new gtk.ProgressBar
+  hbox.add hbox2
+  hbox.add hbox3
+  hbox.add progress_hbox
+  progress_hbox.add progressbar
+  progressbar.setFraction 0.45
+
+
+  entry.setText 'A teeheehee!'
+  entry.setVisibility true
+
+  entry.on 'changed', ->
+    console.log 'changed'
+
+  button = new gtk.Button
+  button.setLabel 'Test Button'
+
+  img = new gtk.Image
+  img.setFromFile './data/ngtk.png'
+  button.setImage img
+
+  button.on 'clicked', ->
+    console.log 'clicked'
+    dialog = new gtk.MessageDialog window, gtk.DIALOG_DESTROY_WITH_PARENT, gtk.MESSAGE_INFO, gtk.BUTTONS_OK, 'Node.js + GTK <3'
+    dialog.show()
+
+  hbox2.add button
+  hbox3.add entry
+
+  window.setTitle 'Node'
+  window.setResizable true
+  window.setDefaultSize()
+
+  window.on 'destroy', ->
+    console.log window.getOpacity()
+    console.log window.getPosition()
+    console.log window.getSize()
+    console.log window.getResizable true
+    console.log window.getTitle()
+    console.log 'OMG'
 
   window.show()

--- a/test.js
+++ b/test.js
@@ -1,62 +1,50 @@
+var gtk;
 console.log('test.js');
-var gtk = require('./build/default/gtk');
-var fs  = require('fs');
-
-process.nextTick(function () {
+gtk = require('./build/default/gtk');
+process.nextTick(function() {
+  var button, entry, hbox, hbox2, hbox3, img, progress_hbox, progressbar, window;
   gtk.init();
-
-  var window = new gtk.Window();
-  var hbox   = new gtk.Hbox();
-  var progress_hbox = new gtk.Hbox();
+  window = new gtk.Window;
+  hbox = new gtk.Hbox;
+  progress_hbox = new gtk.Hbox;
   window.add(hbox);
-
-  var hbox2 = new gtk.Hbox();
-  var hbox3 = new gtk.Hbox();
-  var entry = new gtk.Entry();
-  var progressbar = new gtk.ProgressBar();
+  hbox2 = new gtk.Hbox;
+  hbox3 = new gtk.Hbox;
+  entry = new gtk.Entry;
+  progressbar = new gtk.ProgressBar;
   hbox.add(hbox2);
   hbox.add(hbox3);
   hbox.add(progress_hbox);
   progress_hbox.add(progressbar);
   progressbar.setFraction(0.45);
-
-
   entry.setText('A teeheehee!');
   entry.setVisibility(true);
-
-  entry.on('changed', function () {
-    console.log('changed');
+  entry.on('changed', function() {
+    return console.log('changed');
   });
-
-  var button = new gtk.Button();
-  //button.setLabel('Test Button');
-
-  var img = new gtk.Image();
+  button = new gtk.Button;
+  button.setLabel('Test Button');
+  img = new gtk.Image;
   img.setFromFile('./data/ngtk.png');
   button.setImage(img);
-
-  button.on('clicked', function () {
+  button.on('clicked', function() {
+    var dialog;
     console.log('clicked');
-    var dialog = new gtk.MessageDialog(window, gtk.DIALOG_DESTROY_WITH_PARENT,
-                         gtk.MESSAGE_INFO, gtk.BUTTONS_OK, 'Node.js + GTK <3');
-    dialog.show();
+    dialog = new gtk.MessageDialog(window, gtk.DIALOG_DESTROY_WITH_PARENT, gtk.MESSAGE_INFO, gtk.BUTTONS_OK, 'Node.js + GTK <3');
+    return dialog.show();
   });
-
   hbox2.add(button);
   hbox3.add(entry);
-
   window.setTitle('Node');
   window.setResizable(true);
   window.setDefaultSize();
-
-  window.on('destroy', function () {
+  window.on('destroy', function() {
     console.log(window.getOpacity());
     console.log(window.getPosition());
     console.log(window.getSize());
     console.log(window.getResizable(true));
     console.log(window.getTitle());
-    console.log('OMG');
+    return console.log('OMG');
   });
-
-  window.show();
+  return window.show();
 });


### PR DESCRIPTION
I have implemented signals in a way that does not segfault when signals have more arguments. It does require more code - a function for each different signal signature - but it has the benefit of actually working. I have implemented some of the simpler signals on the Widget and Button classes. I am still working out exactly how to translate all the possible arguments passed to a signal to equivalent JavaScript objects, but this is a start.

See issue #1 for the initial problem.
